### PR TITLE
Allow per node protection bypass / protection override #11 #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ Example definition:
 	end,
 ```
 
+Parameter `protection_bypass_read = { "mytool_copy" }`
+Bypass all read protection checks when using tool if player has listed privs.
+
+Parameter `protection_bypass_write = { "mytool_admin" }`
+Bypass all write protection checks when using tool if player has listed privs.
+
+Callback `allowed = before_read(nodedef, pos, player)`
+Executed before node reading is called, this method can override all protection checks.
+Above protection_bypass_read parameters might not work if this is overridden.
+
+Callback `allowed = before_write(nodedef, pos, player)`
+Executed before node reading is called, this method can override all protection checks.
+Above protection_bypass_write parameters might not work if this is overridden.
+
 ### Metatool API methods (commonly used)
 
 `mytool = metatool:register_tool(name, definition)`
@@ -111,7 +125,7 @@ Example definition:
 
 ### Metatool API methods (for special needs)
 
-`node, pos = metatool:get_node(tool, player, pointed_thing)`
+`node, pos, nodedef = metatool:get_node(tool, player, pointed_thing)`
 
 `metatool.write_data(itemstack, data, description)`
 

--- a/metatool/api.lua
+++ b/metatool/api.lua
@@ -89,11 +89,13 @@ metatool = {
 
 	is_protected = function(pos, player, privs)
 		local name = player:get_player_name()
-		if minetest.is_protected(pos, name) then
-			local bypass = privs and minetest.check_player_privs(player, privs) or false
-			-- node is protected record violation even with bypass priv
+		if privs and minetest.check_player_privs(player, privs) then
+			-- player is allowed to bypass protection checks
+			return false
+		elseif minetest.is_protected(pos, name) then
+			-- node is protected record violation
 			minetest.record_protection_violation(pos, name)
-			return not bypass
+			return true
 		end
 		return false
 	end,


### PR DESCRIPTION
This adds before_read and before_write callbacks.
Callback return value is checked and it it evaluates to true then read or write is allowed, if false then read/write is disallowed.

Callbacks can be overridden for each registered node, tool wide callback not available.

This also adds parameters for registered nodes:
protection_bypass_read and protection_bypass_write. Both take list of privileges and those privileges will be used to check if protections can be bypassed.
Privilege can for example be "interact" to allow everyone to bypass protection checks.

Implements https://github.com/S-S-X/metatool/issues/11
Dependency for https://github.com/S-S-X/metatool/issues/9