### PR TITLE
Add teleport tube listing function

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -8,6 +8,7 @@ read_globals = {
 	"minetest",
 	"default",
 	"pipeworks",
+	"vector",
 	"ItemStack",
 	"Settings",
 }

--- a/metatool/formspec.lua
+++ b/metatool/formspec.lua
@@ -1,0 +1,71 @@
+
+--local S = metatool.S
+
+metatool.form = {}
+
+-- container for form handler callback methods
+metatool.form.handlers = {}
+
+local getformname = function(formname)
+	return string.format("metatool:%s", formname)
+end
+
+local hasform = function(name)
+	return type(metatool.form.handlers[name]) == 'table'
+end
+
+local global_form_handler_registered
+metatool.form.register_global_handler = function()
+	if not global_form_handler_registered then
+		global_form_handler_registered = true
+		minetest.register_on_player_receive_fields(metatool.form.on_receive)
+	end
+end
+
+metatool.form.on_receive = function(player, formname, fields)
+	if metatool.form.handlers[formname] == nil then
+		-- form handler does not exist
+		return
+	end
+	if not fields then
+		-- No input received, do nothing
+		return
+	end
+	if metatool.form.handlers[formname].on_receive then
+		-- call actual form handler
+		metatool.form.handlers[formname].on_receive(player, fields)
+	end
+end
+
+metatool.form.on_create = function(player, formname, data)
+	local name = getformname(formname)
+	if not hasform(name) then
+		return
+	end
+	-- call actual form handler
+	if metatool.form.handlers[name].on_create then
+		return metatool.form.handlers[name].on_create(player, data)
+	end
+	return metatool.form.handlers[name].formspec
+end
+
+-- Either on_create for dynamic formspecs or formspec for static formspecs.
+-- on_create will be priorized if both defined
+metatool.form.register_form = function(formname, on_create, on_receive, formspec)
+	metatool.form.register_global_handler()
+	local name = getformname(formname)
+	metatool.form.handlers[name] = {
+		formspec = formspec,
+		on_create = on_create,
+		on_receive = on_receive,
+	}
+end
+
+metatool.form.show = function(player, formname, data)
+	local name = getformname(formname)
+	if not hasform(name) then
+		return
+	end
+	local formspec = metatool.form.on_create(player, formname, data)
+	minetest.show_formspec(player:get_player_name(), formname, formspec)
+end

--- a/metatool/init.lua
+++ b/metatool/init.lua
@@ -13,5 +13,6 @@ metatool = {
 dofile(metatool.modpath .. '/settings.lua')
 dofile(metatool.modpath .. '/api.lua')
 dofile(metatool.modpath .. '/command.lua')
+dofile(metatool.modpath .. '/formspec.lua')
 
 print('[OK] MetaTool loaded')

--- a/tubetool/nodes/teleport_tube.lua
+++ b/tubetool/nodes/teleport_tube.lua
@@ -11,10 +11,60 @@ for i=1,10 do
 	table.insert(nodes, nodenameprefix .. i)
 end
 
+metatool.form.register_form(
+	'tubetool:teleport_tube_list',
+	function(player, data)
+		local player_pos = player:get_pos()
+		local list = ""
+		for _,tube in ipairs(data.tubes) do
+			list = list ..
+				"," .. math.floor(vector.distance(tube.pos, player_pos)) .. "m" ..
+				"," .. minetest.formspec_escape(string.format("%d,%d,%d",tube.pos.x,tube.pos.y,tube.pos.z)) ..
+				",   " .. (tube.can_receive and "yes" or "no")
+		end
+		local header = minetest.formspec_escape(data.channel) .. ", total " .. #data.tubes .. " tubes]"
+		return "size[8,10;]" ..
+			"label[0,0;Teleport tubes on channel " .. header ..
+			"button_exit[4,9;4,1;exit;Exit]" ..
+			"tablecolumns[text;text;text]" ..
+			"table[0,0.5;7.7,8.5;items;Distance            ,Coords            ,Receive" .. list .. ";]"
+	end
+)
+
 return {
 	nodes = nodes,
 	tooldef = {
 		group = 'teleport tube',
+
+		info = function(node, pos, player)
+			if not pipeworks.tptube or not pipeworks.tptube.get_db then
+				minetest.chat_send_player(
+					player:get_player_name(),
+					'Installed pipeworks version does not have required tptube.get_db function.'
+				)
+				return
+			end
+			local meta = minetest.get_meta(pos)
+			local channel = meta:get_string("channel")
+			if channel == "" then
+				minetest.chat_send_player(
+					player:get_player_name(),
+					'Invalid channel, impossible to list connected tubes.'
+				)
+				return
+			end
+			local db = pipeworks.tptube.get_db()
+			local tubes = {}
+			for hash,data in pairs(db) do
+				if data.channel == channel then
+					table.insert(tubes, {
+						pos = minetest.get_position_from_hash(hash),
+						can_receive = data.cr == 1,
+					})
+				end
+			end
+			metatool.form.show(player, 'tubetool:teleport_tube_list', {channel = channel, tubes = tubes})
+		end,
 
 		copy = function(node, pos, player)
 			local meta = minetest.get_meta(pos)


### PR DESCRIPTION
Resolves #20 by adding optional on_read_info / info callbacks for tools and nodes.
Partially implements #21 by adding info method and formspec for teleport tubes