### PR TITLE
Allow setting/using machine_use_priv

### DIFF
--- a/luatool/init.lua
+++ b/luatool/init.lua
@@ -14,6 +14,9 @@ local tool = metatool:register_tool('luatool', {
 	name = 'LuaTool',
 	texture = 'luatool_wand.png',
 	recipe = recipe,
+	settings = {
+		machine_use_priv = 'server'
+	},
 	on_read_node = function(tooldef, player, pointed_thing, node, pos)
 		local data, group = tooldef:copy(node, pos, player)
 		local description = type(data) == 'table' and data.description or ('Data from ' .. minetest.pos_to_string(pos))

--- a/metatool/api.lua
+++ b/metatool/api.lua
@@ -219,11 +219,18 @@ end
 
 -- Called when registered tool is used
 metatool.on_use = function(self, toolname, itemstack, player, pointed_thing)
-	if not player or type(player) == 'table' then
-		return
-	end
 
 	local tool = self.tools[toolname]
+	if not player or not tool then return end
+
+	if type(player) ~= 'userdata' then
+		-- if tool has machine_use_priv and player has it allow using tool even if player is not userdata (fake player)
+		local machine_use_priv = tool.settings.machine_use_priv
+		if not machine_use_priv or not metatool.check_privs(player, machine_use_priv) then
+			return
+		end
+	end
+
 	if self.privileged_tools[toolname] then
 		if not metatool.check_privs(player, tool.privs) then
 			minetest.chat_send_player(player:get_player_name(), 'You are not allowed to use this tool.')
@@ -397,8 +404,8 @@ metatool.register_node = function(self, toolname, name, definition, override)
 end
 
 metatool.get_node = function(self, tool, player, pointed_thing)
-	if not player or type(player) == 'table' or not pointed_thing then
-		-- not valid player or fake player, fake player is not supported (yet)
+	if not player or not pointed_thing then
+		-- not valid player or pointed_thing
 		return
 	end
 


### PR DESCRIPTION
Closes #48

Adds tool setting `machine_use_priv` that is checked if fake player is using tool.
Fake player is allowed to use tool if `machine_use_priv` is set and fake player has `machine_use_priv`.

Added default `machine_use_priv` privilege for luatool: `server`.

Privilege can be configured using metatool configuration file, for example to allow moderators to use luatool with machines add this to configuration file:
```ini
metatool:luatool:machine_use_priv = ban
```

Similar configuration should work for any other tool but none of other tools have been tested with machines.