### PR TITLE
Teleport tube listings for stored teleport tube

### DIFF
--- a/metatool/api.lua
+++ b/metatool/api.lua
@@ -251,10 +251,10 @@ metatool.on_use = function(self, toolname, itemstack, player, pointed_thing)
 			-- Execute on_read_node when tool is used on node and sneak is held
 			if tool.on_read_info then
 				-- Tool info method defined, call through it and let it handle nodes
-				tool.on_read_info(tool, player, pointed_thing, node, pos, nodedef)
+				tool.on_read_info(tool, player, pointed_thing, node, pos, nodedef, itemstack)
 			else
 				-- Only node definition had info method available, use it directly
-				nodedef.info(node, pos, player)
+				nodedef.info(node, pos, player, itemstack)
 			end
 		elseif not use_info and nodedef.before_read(nodedef, pos, player) then
 			-- Execute on_read_node when tool is used on node and special or sneak is held

--- a/tubetool/init.lua
+++ b/tubetool/init.lua
@@ -26,6 +26,21 @@ local tool = metatool:register_tool('tubetool', {
 	end,
 })
 
+-- Create namespace containing tubetool common functions
+tool:ns({
+	pipeworks_tptube_api_check = function(player)
+		if not pipeworks.tptube or not pipeworks.tptube.get_db then
+			minetest.chat_send_player(
+				player:get_player_name(),
+				'Installed pipeworks version does not have required tptube.get_db function.'
+			)
+			return false
+		end
+		return true
+	end,
+})
+
+-- TODO: Very early name for metatool:tubetool, probably not found anywhere in wild and could be removed
 minetest.register_alias('tubetool:wand', 'metatool:tubetool')
 
 -- nodes
@@ -33,3 +48,4 @@ tool:load_node_definition(dofile(modpath .. '/nodes/mese_tube.lua'))
 tool:load_node_definition(dofile(modpath .. '/nodes/teleport_tube.lua'))
 tool:load_node_definition(dofile(modpath .. '/nodes/sand_tube.lua'))
 tool:load_node_definition(dofile(modpath .. '/nodes/injector.lua'))
+tool:load_node_definition(dofile(modpath .. '/nodes/any.lua'))

--- a/tubetool/nodes/any.lua
+++ b/tubetool/nodes/any.lua
@@ -1,8 +1,6 @@
 --
--- Register fallback node handler (wildcard node) for sharetool
+-- Register fallback node handler (wildcard node) for tubetool
 --
-
-local S = metatool.S
 
 local ns = metatool.ns('tubetool')
 

--- a/tubetool/nodes/any.lua
+++ b/tubetool/nodes/any.lua
@@ -1,0 +1,50 @@
+--
+-- Register fallback node handler (wildcard node) for sharetool
+--
+
+local S = metatool.S
+
+local ns = metatool.ns('tubetool')
+
+--luacheck: ignore unused argument node player
+return {
+	name = '*',
+	nodes = '*',
+	tooldef = {
+		group = '*',
+
+		before_read = function() return false end,
+		before_write = function() return false end,
+		before_info = function() return true end,
+		copy = function() end,
+		paste = function() end,
+
+		info = function(node, pos, player, itemstack)
+			-- Display teleport tubes form if tool has teleport tube data
+			local tooldata = metatool.read_data(itemstack)
+			if not tooldata or tooldata.group ~= 'teleport tube' then return end
+			if not ns.pipeworks_tptube_api_check(player) then return end
+
+			local channel = tooldata.data.channel
+			if channel == "" then
+				minetest.chat_send_player(
+					player:get_player_name(),
+					'Invalid channel, impossible to list connected tubes.'
+				)
+				return
+			end
+			local db = pipeworks.tptube.get_db()
+			local tubes = {}
+			for hash,data in pairs(db) do
+				if data.channel == channel then
+					table.insert(tubes, {
+						pos = minetest.get_position_from_hash(hash),
+						can_receive = data.cr == 1,
+					})
+				end
+			end
+			metatool.form.show(player, 'tubetool:teleport_tube_list', {pos = pos, channel = channel, tubes = tubes})
+		end,
+
+	}
+}

--- a/tubetool/nodes/teleport_tube.lua
+++ b/tubetool/nodes/teleport_tube.lua
@@ -13,6 +13,8 @@ for i=1,10 do
 	table.insert(nodes, nodenameprefix .. i)
 end
 
+local ns = metatool.ns('tubetool')
+
 local tp_tube_form_index = {}
 
 metatool.form.register_form(
@@ -60,13 +62,7 @@ return {
 		protection_bypass_read = "interact",
 
 		info = function(node, pos, player)
-			if not pipeworks.tptube or not pipeworks.tptube.get_db then
-				minetest.chat_send_player(
-					player:get_player_name(),
-					'Installed pipeworks version does not have required tptube.get_db function.'
-				)
-				return
-			end
+			if not ns.pipeworks_tptube_api_check(player) then return end
 			local meta = minetest.get_meta(pos)
 			local channel = meta:get_string("channel")
 			if channel == "" then


### PR DESCRIPTION
Closes #47 
Tubetool info function can target any node and if tool has stored tp tube information teleport tube list formspec is displayed.