### PR TITLE
Luatool copy/inspect mem

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -14,4 +14,5 @@ read_globals = {
 	"vector",
 	"ItemStack",
 	"Settings",
+	"dump",
 }

--- a/luatool/init.lua
+++ b/luatool/init.lua
@@ -27,6 +27,83 @@ local tool = metatool:register_tool('luatool', {
 	end,
 })
 
+local function find_luatool_stack(player, refstack)
+	local inv = player:get_inventory()
+	local invsize = inv:get_size('main')
+	local name = refstack:get_name()
+	local count = refstack:get_count()
+	local meta = refstack:get_meta()
+	local invindex, invstack
+	for i=1,invsize do
+		local stack = inv:get_stack('main', i)
+		if stack:get_count() == count and stack:get_name() == name and stack:get_meta():equals(meta) then
+			-- This item stack seems very similar to one that were used originally, use this
+			invindex = i
+			invstack = stack
+			break
+		end
+	end
+	return inv, invindex, invstack
+end
+
+-- lua controller / lua tube mem inspection form
+metatool.form.register_form(
+	'luatool:mem_inspector',
+	function(player, data)
+		local raw_mem = minetest.deserialize(data.mem)
+		local fmt_mem = dump(raw_mem)
+		return "formspec_version[3]size[10,12;]label[0.1,0.5;" ..
+			"Memory contents for " .. minetest.formspec_escape(data.name) .. "]" ..
+			"button_exit[0,11;5,1;save;Save for programming]" ..
+			"button_exit[5,11;5,1;exit;Exit]" ..
+			"textarea[0,1;10,10;mem;;" .. minetest.formspec_escape(fmt_mem) .. "]"
+	end,
+	function(player, fields, data)
+		if fields.save and fields.quit then
+			local itemstack = data.itemstack
+			if not itemstack then
+				minetest.chat_send_player(player:get_player_name(), 'Could not save device memory contents.')
+				return
+			end
+			local inv, index, stack = find_luatool_stack(player, itemstack)
+			if stack then
+				local tooldata = metatool.read_data(stack) or {data={},group=data.group}
+				local description = nil
+				if not tooldata.data.mem_stored then
+					if tooldata.data.code then
+						description = stack:get_meta():get_string('description') .. " with memory"
+					else
+						description = "CPU memory contents"
+					end
+				end
+				tooldata.data.mem = data.mem
+				tooldata.data.mem_stored = true
+				metatool.write_data(stack, tooldata, description)
+				inv:set_stack('main', index, stack)
+				minetest.chat_send_player(
+					player:get_player_name(),
+					'Device memory contents stored in tool memory.'
+				)
+			else
+				minetest.chat_send_player(player:get_player_name(), 'Could not save device memory contents.')
+			end
+		end
+	end
+)
+
+tool:ns({
+	info = function(node, pos, player, itemstack, group)
+		local meta = minetest.get_meta(pos)
+		local mem = meta:get_string('lc_memory')
+		metatool.form.show(player, 'luatool:mem_inspector', {
+			group = group, -- tool storage group for stack manipulation
+			itemstack = itemstack, -- tool itemstack
+			name = "CPU at " .. minetest.pos_to_string(pos),
+			mem = mem,
+		})
+	end,
+})
+
 -- nodes
 local modpath = minetest.get_modpath('luatool')
 tool:load_node_definition(dofile(modpath .. '/nodes/luatube.lua'))

--- a/luatool/nodes/luacontroller.lua
+++ b/luatool/nodes/luacontroller.lua
@@ -31,6 +31,8 @@ for i=0,15 do
 end
 table.insert(nodes, nodenameprefix .. '_burnt')
 
+local ns = metatool.ns('luatool')
+
 --luacheck: ignore unused argument node player
 return {
 	name = 'luacontroller',
@@ -38,6 +40,10 @@ return {
 	tooldef = {
 		group = 'lua controller',
 		protection_bypass_read = "interact",
+
+		info = function(node, pos, player, itemstack)
+			return ns.info(node, pos, player, itemstack, 'lua controller')
+		end,
 
 		copy = function(node, pos, player)
 			local meta = minetest.get_meta(pos)
@@ -53,10 +59,14 @@ return {
 		end,
 
 		paste = function(node, pos, player, data)
-			-- restore settings and update tube, no api available
+			-- restore settings and update lua controller, no api available
+			local meta = minetest.get_meta(pos)
+			if data.mem_stored then
+				meta:set_string("lc_memory", data.mem)
+			end
 			local fields = {
 				program = 1,
-				code = data.code,
+				code = data.code or meta:get_string("code"),
 			}
 			local nodedef = minetest.registered_nodes[node.name]
 			nodedef.on_receive_fields(pos, "", fields, player)

--- a/luatool/nodes/luatube.lua
+++ b/luatool/nodes/luatube.lua
@@ -31,6 +31,8 @@ for i=0,63 do
 end
 table.insert(nodes, nodenameprefix .. '_burnt')
 
+local ns = metatool.ns('luatool')
+
 --luacheck: ignore unused argument node player
 return {
 	name = 'luatube',
@@ -38,6 +40,10 @@ return {
 	tooldef = {
 		group = 'lua tube',
 		protection_bypass_read = "interact",
+
+		info = function(node, pos, player, itemstack)
+			return ns.info(node, pos, player, itemstack, 'lua tube')
+		end,
 
 		copy = function(node, pos, player)
 			local meta = minetest.get_meta(pos)
@@ -54,9 +60,13 @@ return {
 
 		paste = function(node, pos, player, data)
 			-- restore settings and update tube, no api available
+			local meta = minetest.get_meta(pos)
+			if data.mem_stored then
+				meta:set_string("lc_memory", data.mem)
+			end
 			local fields = {
 				program = 1,
-				code = data.code,
+				code = data.code or meta:get_string("code"),
 			}
 			local nodedef = minetest.registered_nodes[node.name]
 			nodedef.on_receive_fields(pos, "", fields, player)


### PR DESCRIPTION
Closes #52 
Common info function trigger: hold sneak and use to display mem dump.

Mem storage can be used with empty tool or tool that already contains code.
If used with empty tool then whole stack will get memory stored and using tools on lua controller only replaces memory but not code. Tool description is "CPU memory contents".
If use with tool that contains code then luac memory is stored to tool memory with code, when used both code and memory is applied to lua controller. Description says "Lua controller at x,y,z with memory"