### PR TITLE
Add some tests for node specific settings

### DIFF
--- a/metatool/spec/api_spec.lua
+++ b/metatool/spec/api_spec.lua
@@ -266,6 +266,62 @@ describe("Metatool API node registration", function()
 
 	end)
 
+	it("Register node with extended configuration", function()
+		local tool = metatool.tool("testtool2")
+		assert.is_table(tool)
+		assert.equals("metatool:testtool2", tool.name)
+		assert.is_table(tool)
+
+		local definition = {
+			name = 'testnode3',
+			nodes = "testnode3",
+			tooldef = {
+				group = 'test node',
+				protection_bypass_read = "default_bypass_read_priv",
+				settings = {
+					allow_doing_x = true,
+					message_for_y = "test y message",
+				},
+				copy = function(node, pos, player)
+					print("nodedef copy callback executed")
+				end,
+				paste = function(node, pos, player, data)
+					print("nodedef paste callback executed")
+				end,
+			}
+		}
+		tool:load_node_definition(definition)
+
+		assert.is_table(tool.nodes)
+		assert.is_table(tool.nodes.testnode1)
+		assert.is_table(tool.nodes.testnode2)
+		assert.is_table(tool.nodes.testnode3)
+
+		assert.is_function(tool.nodes.testnode3.before_read)
+		assert.is_function(tool.nodes.testnode3.before_write)
+
+		assert.not_equals(definition.tooldef.copy, tool.nodes.testnode1.copy)
+		assert.equals(definition.tooldef.copy, tool.nodes.testnode3.copy)
+		assert.equals(definition.tooldef.paste, tool.nodes.testnode3.paste)
+		assert.equals("testtool2_testnode2_bypass_write", tool.nodes.testnode1.protection_bypass_write)
+		assert.equals("testtool2_testnode2_bypass_write", tool.nodes.testnode2.protection_bypass_write)
+		assert.is_nil(tool.nodes.testnode3.protection_bypass_write)
+		assert.equals("default_bypass_read_priv", tool.nodes.testnode3.protection_bypass_read)
+		assert.equals("default_bypass_read_priv", tool.nodes.testnode3.settings.protection_bypass_read)
+		assert.equals(true, tool.nodes.testnode3.settings.allow_doing_x)
+		assert.equals("test y message", tool.nodes.testnode3.settings.message_for_y)
+		assert.is_nil(tool.nodes.testnode3.message_for_y)
+
+		local expected_settings = {
+			protection_bypass_read = "default_bypass_read_priv",
+			allow_doing_x = true,
+			message_for_y = "test y message",
+		}
+		assert.same(expected_settings, tool.nodes.testnode3.settings)
+		assert.same(expected_settings, tool.nodes.testnode3.settings)
+
+	end)
+
 end)
 
 --[[

--- a/metatool/spec/fixtures/minetest.lua
+++ b/metatool/spec/fixtures/minetest.lua
@@ -7,6 +7,7 @@ fixture("minetest/misc_helpers")
 _G.minetest.registered_nodes = {
 	testnode1 = {},
 	testnode2 = {},
+	testnode3 = {},
 }
 
 _G.minetest.registered_chatcommands = {}

--- a/metatool/spec/settings_spec.lua
+++ b/metatool/spec/settings_spec.lua
@@ -6,8 +6,8 @@
 		- Only default configuration
 		- Configuration only for single tool
 		- Metatool core/API configuration
-		- No configuration (empty file)
-		- No configuration file at, not even empty file
+		- No configuration, empty file
+		- No configuration, not even empty file
 --]]
 
 dofile("spec/test_helpers.lua")


### PR DESCRIPTION
Simple tests for nodedef extended settings:
```lua
group = 'test node',
protection_bypass_read = "default_bypass_read_priv",
settings = {
	allow_doing_x = true,
	message_for_y = "test y message",
},
```