### PR TITLE
Add support for colored travelnets

### DIFF
--- a/magic_pen/nodes/travelnet.lua
+++ b/magic_pen/nodes/travelnet.lua
@@ -14,6 +14,11 @@ local definition = {
 	name = 'travelnet',
 	nodes = {
 		'travelnet:travelnet',
+		'travelnet:travelnet_red',
+		'travelnet:travelnet_blue',
+		'travelnet:travelnet_green',
+		'travelnet:travelnet_black',
+		'travelnet:travelnet_white',
 		'locked_travelnet:travelnet',
 		'travelnet:travelnet_private',
 		'travelnet:elevator',

--- a/sharetool/nodes/any.lua
+++ b/sharetool/nodes/any.lua
@@ -39,6 +39,11 @@ end
 
 local travelnet_nodes = {
 	['travelnet:travelnet'] = 1,
+	['travelnet:travelnet_red'] = 1,
+	['travelnet:travelnet_blue'] = 1,
+	['travelnet:travelnet_green'] = 1,
+	['travelnet:travelnet_black'] = 1,
+	['travelnet:travelnet_white'] = 1,
 	['locked_travelnet:travelnet'] = 1,
 	['travelnet:travelnet_private'] = 1,
 	['travelnet:elevator'] = 1,

--- a/sharetool/nodes/travelnet.lua
+++ b/sharetool/nodes/travelnet.lua
@@ -6,6 +6,11 @@ local definition = {
 	name = 'travelnet',
 	nodes = {
 		'travelnet:travelnet',
+		'travelnet:travelnet_red',
+		'travelnet:travelnet_blue',
+		'travelnet:travelnet_green',
+		'travelnet:travelnet_black',
+		'travelnet:travelnet_white',
 		'locked_travelnet:travelnet',
 		'travelnet:travelnet_private',
 		'travelnet:elevator',


### PR DESCRIPTION
Fixes #86 

Adds support for colored travelnets: sharetool and magic pen.

Based on https://github.com/mt-mods/travelnet/blob/master/travelnet.lua