### PR TITLE
Sharetool increase default radius limit

### DIFF
--- a/sharetool/init.lua
+++ b/sharetool/init.lua
@@ -22,7 +22,8 @@ local sharetool = {
 	recipe = recipe,
 	allow_use_empty = true,
 	settings = {
-		shared_account = 'shared'
+		shared_account = 'shared',
+		max_radius = 45,
 	},
 }
 


### PR DESCRIPTION
* A lot better performance for larger areas (from seconds to milliseconds).
* Increased max radius and made it configurable: `metatool:sharetool:max_radius = 45`.
  Old hardcoded radius limit was 5, new default is 45.
* Default operation radius stays at 5 (formspec init).