### PR TITLE
Update form API and some tool forms

### DIFF
--- a/metatool/formspec.lua
+++ b/metatool/formspec.lua
@@ -137,7 +137,8 @@ function Form:field(def)
 end
 
 function Form:render()
-	return self.formspec .. table.concat(self.elements)
+	-- Label is hack around formspecs not updating if nothing but field defaults changed
+	return self.formspec .. table.concat(self.elements) .. "label[-9,-9;" .. os.clock() .. "]"
 end
 
 metatool.form = {
@@ -202,7 +203,6 @@ function metatool.form.on_receive(player, formname, fields)
 		local name = data and data.name
 		if name ~= formname then
 			minetest.chat_send_player(playername, "Bug: Form name mismatch: " .. formname)
-			print(name, formname, data and data.nonce, matcher())
 			return true
 		end
 		local secure = data and data.nonce == matcher()

--- a/metatool/formspec.lua
+++ b/metatool/formspec.lua
@@ -26,8 +26,6 @@ Form.__index = Form
 setmetatable(Form, {
 	__call = function(_, def)
 		local obj = {
-			strict = def and (def.strict ~= false) or true,
-			nonce = nil,
 			width = def and def.width or 8,
 			height = def and def.height or 8,
 			xspacing = def and (def.xspacing or def.spacing) or 0.1,
@@ -138,9 +136,8 @@ function Form:field(def)
 	return self
 end
 
-function Form:render(nonce)
-	local nonce_field = ("field[-99,-99;0,0;metatool_form_nonce;;%s]"):format(nonce)
-	return self.formspec .. table.concat(self.elements) .. nonce_field
+function Form:render()
+	return self.formspec .. table.concat(self.elements)
 end
 
 metatool.form = {
@@ -150,7 +147,7 @@ metatool.form = {
 -- container for form handler callback methods
 metatool.form.handlers = {}
 
-local get_formname = function(name)
+local function get_formname(name)
 	if not name then
 		return
 	end
@@ -166,8 +163,8 @@ local get_formname = function(name)
 	return string.format("metatool:%s", name)
 end
 
-local has_form = function(name)
-	return type(metatool.form.handlers[name]) == 'table'
+local function has_form(name)
+	return name and (type(metatool.form.handlers[name]) == 'table')
 end
 
 -- Temporary storage for form data references
@@ -175,48 +172,65 @@ end
 -- Links are destroyed after receiving fields and data is lost if not maintained by caller
 local formdata = {}
 
+local function destroy_formdata(player)
+	local name = type(player) == "userdata" and player:get_player_name() or player
+	if name then
+		formdata[name] = nil
+	end
+end
+
 local global_form_handler_registered
-metatool.form.register_global_handler = function()
+function metatool.form.register_global_handler()
 	if not global_form_handler_registered then
 		global_form_handler_registered = true
 		print("metatool.form.register_global_handler Registering global formspec handler for Metatool")
 		minetest.register_on_player_receive_fields(metatool.form.on_receive)
+		minetest.register_on_leaveplayer(destroy_formdata)
 	end
 end
 
-metatool.form.on_receive = function(player, formname, fields)
-	if type(metatool.form.handlers[formname]) ~= "table" then
+function metatool.form.on_receive(player, formname, fields)
+	local matcher = formname:gmatch("([^~]+)")
+	formname = matcher()
+	if not has_form(formname) then
 		-- form handler does not exist
 		return
 	end
-	if not fields then
-		-- No input received, do nothing
-		return
-	end
-	if metatool.form.handlers[formname].on_receive then
+	if fields and metatool.form.handlers[formname].on_receive then
 		local playername = player:get_player_name()
-		local data = formdata[playername] and formdata[playername][formname]
-		local secure = data and data.nonce == fields.metatool_form_nonce
-		local strict = data and data.strict
+		local data = formdata[playername]
+		local name = data and data.name
+		if name ~= formname then
+			minetest.chat_send_player(playername, "Bug: Form name mismatch: " .. formname)
+			print(name, formname, data and data.nonce, matcher())
+			return true
+		end
+		local secure = data and data.nonce == matcher()
 		local result
 		-- call actual form handler
-		if not strict or secure then
+		if secure then
 			result = metatool.form.handlers[formname].on_receive(player, fields, data.data, secure)
 		elseif not fields.quit then
-			minetest.chat_send_player(player:get_player_name(), "Bug: Invalid security token for form " .. formname)
+			minetest.chat_send_player(playername, "Bug: Invalid security token for form " .. formname)
 		end
 		if result and not fields.quit then
-			minetest.close_formspec(player:get_player_name(), formname)
+			minetest.close_formspec(playername, formname)
 		end
-		if (result or fields.quit) and data then
-			formdata[playername][formname] = nil
+		if fields.quit and data then
+			formdata[playername] = nil
 		elseif result == false then
+			-- Update formspec and send to player
 			metatool.form.show(player, formname, data.data)
+		elseif type(result) == "string" then
+			-- Switch formspec and send to player
+			metatool.form.show(player, result, data.data)
 		end
 	end
+	-- this was our form, tell server to stop processing callbacks
+	return true
 end
 
-metatool.form.on_create = function(player, formname, data)
+function metatool.form.on_create(player, formname, data)
 	if has_form(formname) and type(metatool.form.handlers[formname].on_create) == "function" then
 		-- Use callback to get formspec definition
 		return metatool.form.handlers[formname].on_create(player, data)
@@ -225,7 +239,7 @@ end
 
 -- on_create should be function that returns Form object.
 -- on_receive is function that receives fields when form is submitted, can be nil.
-metatool.form.register_form = function(formname, formdef)
+function metatool.form.register_form(formname, formdef)
 	local name = get_formname(formname)
 	if not name then
 		print(S("metatool.form.register_form Registration failed, invalid formname: %s", formname))
@@ -245,29 +259,28 @@ end
 
 -- display formspec to player, if optional data variable is given then it will be
 -- saved and forwarded to on_create and on_receive form handler callback functions.
-metatool.form.show = function(player, formname, data)
+function metatool.form.show(player, formname, data)
 	local name = get_formname(formname)
 	if has_form(name) then
 		-- Construct form
 		local nonce = generate_nonce()
-		local form = metatool.form.on_create(player, name, data, nonce)
+		local form = metatool.form.on_create(player, name, data)
+		local playername = player:get_player_name()
 		if type(form) ~= "table" then
-			minetest.chat_send_player(player:get_player_name(), "Bug: Attempt to open invalid form " .. formname)
+			minetest.chat_send_player(playername, "Bug: Attempt to open invalid form " .. formname)
 			return
 		end
 		if metatool.form.handlers[name].on_receive then
 			-- Store temporary data ref if form input is processed somehow
-			local playername = player:get_player_name()
-			if not formdata[playername] then
-				formdata[playername] = {}
-			end
-			formdata[playername][name] = {
-				strict = form.strict,
+			formdata[playername] = {
+				name = name,
 				nonce = nonce,
 				data = data,
 			}
 		end
 		-- Show form to player
-		minetest.show_formspec(player:get_player_name(), name, form:render(nonce))
+		minetest.show_formspec(playername, name .. "~" .. nonce, form:render())
+	else
+		minetest.chat_send_player(player:get_player_name(), "Bug: Metatool form does not exist " .. formname)
 	end
 end

--- a/sharetool/nodes/travelnet.lua
+++ b/sharetool/nodes/travelnet.lua
@@ -275,15 +275,9 @@ metatool.form.register_form("sharetool:transfer-travelnet", {
 			end
 		elseif fields.validate then
 			local problems = find_problems(data.pos)
-			metatool.form.show(player, "sharetool:validate-travelnet", {
-				pos = data.pos,
-				node = data.node,
-				owner = data.owner,
-				network = data.network,
-				station = data.station,
-				problems = problems.problems,
-				problems_data = problems.problems_data,
-			})
+			data.problems = problems.problems
+			data.problems_data = problems.problems_data
+			return "sharetool:validate-travelnet"
 		end
 		return true
 	end,

--- a/tubetool/nodes/teleport_tube.lua
+++ b/tubetool/nodes/teleport_tube.lua
@@ -19,9 +19,9 @@ local tp_tube_form_index = {}
 metatool.form.register_form('tubetool:teleport_tube_list', {
 	on_create = function(player, data)
 		local list = ""
-		for _,tube in ipairs(data.tubes) do
+		for i,tube in ipairs(data.tubes) do
 			list = list .. ",1" ..
-				"," .. math.floor(vector.distance(tube.pos, data.pos)) .. "m" ..
+				"," .. math.floor(tube.distance) .. "m" .. (i==1 and " (targeted)" or "") ..
 				"," .. minetest.formspec_escape(string.format("%d,%d,%d",tube.pos.x,tube.pos.y,tube.pos.z)) ..
 				"," .. (tube.can_receive and "yes" or "no")
 		end
@@ -76,12 +76,15 @@ function definition:info(node, pos, player)
 	local tubes = {}
 	for hash,data in pairs(db) do
 		if data.channel == channel then
+			local tube_pos = minetest.get_position_from_hash(hash)
 			table.insert(tubes, {
-				pos = minetest.get_position_from_hash(hash),
+				pos = tube_pos,
+				distance = vector.distance(pos, tube_pos),
 				can_receive = data.cr == 1,
 			})
 		end
 	end
+	table.sort(tubes, function(a, b) return a.distance < b.distance end)
 	metatool.form.show(player, 'tubetool:teleport_tube_list', {pos = pos, channel = channel, tubes = tubes})
 end
 


### PR DESCRIPTION
Bug fix #83
Bug fix #94 
Closes #95 

Moves form token from field to name and prevents creating insecure formspecs, `strict` parameter removed and all form interactions now behave like if `strict` would be always enabled.
Includes dirty hack to force formspec updates on client even if it would be otherwise decided to not update formspec.