### PR TITLE
v1.3.1 tubetool patch

### DIFF
--- a/tubetool/init.lua
+++ b/tubetool/init.lua
@@ -32,7 +32,7 @@ tool:ns({
 		if type(pipeworks) ~= "table" then
 			minetest.chat_send_player(player:get_player_name(), 'Pipeworks mod not installed.')
 			return false
-        end
+		end
 		if not pipeworks.tptube or not pipeworks.tptube.get_db then
 			minetest.chat_send_player(
 				player:get_player_name(),

--- a/tubetool/init.lua
+++ b/tubetool/init.lua
@@ -29,6 +29,10 @@ local tool = metatool:register_tool('tubetool', {
 -- Create namespace containing tubetool common functions
 tool:ns({
 	pipeworks_tptube_api_check = function(player)
+		if type(pipeworks) ~= "table" then
+			minetest.chat_send_player(player:get_player_name(), 'Pipeworks mod not installed.')
+			return false
+        end
 		if not pipeworks.tptube or not pipeworks.tptube.get_db then
 			minetest.chat_send_player(
 				player:get_player_name(),


### PR DESCRIPTION
v1.3.1 release patch. Released to ContentDB.

Consider changing dependencies instead, it might be best to have pipeworks as hard dependency for tubetool.
If that is possible then replace this patch with mod.conf update for new versions / 2.x series.