### PR TITLE
Sort travelnets and elevators when copying

### DIFF
--- a/magic_pen/nodes/travelnet.lua
+++ b/magic_pen/nodes/travelnet.lua
@@ -3,11 +3,40 @@
 --
 
 local function fmt_station(name, data, include_coords)
+	if type(name) ~= "string" then
+		name = "<invalid station data>"
+	end
 	if include_coords then
 		local p = data.pos
+		if type(p) ~= "table" then
+			return ("Station %s at <invalid pos>"):format(name)
+		end
 		return ("Station %s at %d,%d,%d"):format(name, p.x, p.y, p.z)
 	end
 	return name
+end
+
+local function collect_stations(t, network, include_coords, is_elevator)
+	-- directly edit supplied table t
+	if is_elevator then
+		for stname,stdata in pairs(network) do
+			-- elevation included for sorting
+			table.insert(t, {-stdata.pos.y, fmt_station(stname, stdata, include_coords)})
+		end
+	else
+		for stname,stdata in pairs(network) do
+			-- stname included for sorting
+			table.insert(t, {stdata.timestamp, fmt_station(stname, stdata, include_coords)})
+		end
+	end
+	-- sort table based on y location or timestamp
+	table.sort(t, function(a,b)
+		return a[1] < b[1]
+	end);
+	-- drop sorting data
+	for i=1, #t do
+		t[i] = t[i][2]
+	end
 end
 
 local definition = {
@@ -33,9 +62,7 @@ function definition:copy(node, pos, player)
 	local network = meta:get("station_network")
 	local stations = {}
 	if owner and network and travelnet.targets[owner] and travelnet.targets[owner][network] then
-		for stname,stdata in pairs(travelnet.targets[owner][network]) do
-			table.insert(stations, fmt_station(stname, stdata, include_coords))
-		end
+		collect_stations(stations, travelnet.targets[owner][network], include_coords, node.name == "travelnet:elevator")
 	else
 		table.insert(stations, fmt_station(meta:get("station_name"), {pos=pos}, include_coords))
 	end


### PR DESCRIPTION
* Fixed probable bug (not yet happened): copying unconfigured travelnet would crash server.
  Also less probable bug if network data is corrupted.
  This might still leave possible crash scenario when elevators and travelnets are mixed in same network (not intended but possible).
* Added sorting for copied networks either by height or set position (timestamp).