### PR TITLE
Tubetool basic tests and tool bug fixes

### DIFF
--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -39,6 +39,21 @@ jobs:
         COLOR: "${{ steps.mineunit-containertool.outputs.badge-color }}"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - id: mineunit-tubetool
+      uses: mt-mods/mineunit-actions@master
+      with:
+        working-directory: ./tubetool
+        badge-name: tubetool-coverage
+        badge-label: Tubetool Coverage
+    - uses: RubbaBoy/BYOB@v1.2.0
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      with:
+        NAME: "${{ steps.mineunit-tubetool.outputs.badge-name }}"
+        LABEL: "${{ steps.mineunit-tubetool.outputs.badge-label }}"
+        STATUS: "${{ steps.mineunit-tubetool.outputs.badge-status }}"
+        COLOR: "${{ steps.mineunit-tubetool.outputs.badge-color }}"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - id: mineunit-sharetool
       uses: mt-mods/mineunit-actions@master
       with:
@@ -72,6 +87,12 @@ jobs:
           File                             Hits Missed Coverage
           -----------------------------------------------------
           ${{ steps.mineunit-containertool.outputs.mineunit-report }}
+          ```
+          ### Test coverage report for Tubetool sources:
+          ```
+          File                             Hits Missed Coverage
+          -----------------------------------------------------
+          ${{ steps.mineunit-tubetool.outputs.mineunit-report }}
           ```
           ### Test coverage report for Sharetool sources:
           ```

--- a/metatool/util.lua
+++ b/metatool/util.lua
@@ -8,7 +8,10 @@ metatool.util = {}
 --
 
 function metatool.util.pos_to_string(pos)
-	return ("%d,%d,%d"):format(pos.x, pos.y, pos.z)
+	if pos and pos.x and pos.y and pos.z then
+		return ("%d,%d,%d"):format(pos.x, pos.y, pos.z)
+	end
+	return "?,?,?"
 end
 
 function metatool.util.description(pos, node, meta)

--- a/sharetool/nodes/any.lua
+++ b/sharetool/nodes/any.lua
@@ -70,9 +70,11 @@ end
 
 local function get_areas(minpos, maxpos)
 	local results = {}
-	for id,area in pairs(areas and areas:getAreasIntersectingArea(minpos, maxpos)) do
-		if metatool.util.area_in_area(area, {pos1 = minpos, pos2 = maxpos}) then
-			table.insert(results, {id, area.owner, area.name})
+	if areas then
+		for id,area in pairs(areas:getAreasIntersectingArea(minpos, maxpos)) do
+			if metatool.util.area_in_area(area, {pos1 = minpos, pos2 = maxpos}) then
+				table.insert(results, {id, area.owner, area.name})
+			end
 		end
 	end
 	return results

--- a/sharetool/spec/fixtures/metatool.cfg
+++ b/sharetool/spec/fixtures/metatool.cfg
@@ -1,0 +1,1 @@
+metatool:sharetool:privs = server

--- a/tubetool/init.lua
+++ b/tubetool/init.lua
@@ -20,7 +20,7 @@ local tool = metatool:register_tool('tubetool', {
 -- Create namespace containing tubetool common functions
 tool:ns({
 	pipeworks_tptube_api_check = function(player)
-		if not pipeworks.tptube or not pipeworks.tptube.get_db then
+		if not pipeworks or not pipeworks.tptube or not pipeworks.tptube.get_db then
 			minetest.chat_send_player(
 				player:get_player_name(),
 				'Installed pipeworks version does not have required tptube.get_db function.'

--- a/tubetool/spec/fixtures/metatool.cfg
+++ b/tubetool/spec/fixtures/metatool.cfg
@@ -1,0 +1,1 @@
+metatool:tubetool:machine_use_priv = interact

--- a/tubetool/spec/fixtures/pipeworks.lua
+++ b/tubetool/spec/fixtures/pipeworks.lua
@@ -1,0 +1,36 @@
+
+minetest.register_node(":default:dirt", {})
+minetest.register_node(":pipeworks:teleport_tube_1", {})
+
+-- Hash function for pipeworks teleport tube
+local function hash(pos)
+	return string.format("%.30g", minetest.hash_node_position(pos))
+end
+
+local tubedb = {}
+
+pipeworks = {
+	tptube = {
+		get_db = function()
+			return tubedb
+		end,
+	}
+}
+
+local function add_tp_tube(pos, channel, receive)
+	world.set_node(pos, "pipeworks:teleport_tube_1")
+	local meta = minetest.get_meta(pos)
+	meta:set_string("channel", channel)
+	meta:set_int("can_receive", receive and 1 or 0)
+	tubedb[hash({x=1,y=1,z=1})] = {
+		channel = channel,
+		cr = receive and 1 or 0,
+	}
+end
+
+world.clear()
+world.set_node({x=0,y=0,z=0}, "default:dirt")
+
+add_tp_tube({x=1,y=1,z=1}, "SX:private", true)
+add_tp_tube({x=2,y=1,z=1}, "SX;receiver", true)
+add_tp_tube({x=3,y=1,z=1}, "public", true)

--- a/tubetool/spec/mineunit.conf
+++ b/tubetool/spec/mineunit.conf
@@ -1,0 +1,7 @@
+fixture_paths = {
+	"spec/fixtures",
+	"../metatool/spec/fixtures",
+}
+exclude = {
+	"../metatool/",
+}

--- a/tubetool/spec/tool_spec.lua
+++ b/tubetool/spec/tool_spec.lua
@@ -1,0 +1,175 @@
+--[[
+	Regression tests for sharetool
+--]]
+require("mineunit")
+
+mineunit:set_modpath("sharetool", ".")
+
+mineunit("core")
+mineunit("player")
+mineunit("protection")
+mineunit("default/functions")
+
+fixture("metatool")
+fixture("pipeworks")
+
+sourcefile("../metatool/init")
+sourcefile("init")
+
+mineunit:mods_loaded()
+
+local TOOL_NAME = "metatool:tubetool"
+
+local function get_pointed_thing(pos)
+	pos = pos or {x=0,y=0,z=0}
+	return {
+		type = "node",
+		above = {x=pos.x,y=pos.y+1,z=pos.z}, -- Pointing from above to downwards,
+		under = {x=pos.x,y=pos.y,z=pos.z}, -- crosshair at protected node surface
+	}
+end
+
+local function get_tool_itemstack(name, data)
+	local stack = ItemStack(name)
+	if data then
+		metatool.write_data(stack, data)
+	end
+	return stack
+end
+
+describe("Tool behavior", function()
+
+	describe("use on teleport tube", function()
+
+		it("write with privileges", function()
+			local player = Player("Sam", { ban = true })
+			local tool_stack = get_tool_itemstack(TOOL_NAME)
+			local count = tool_stack:get_count()
+			local pointed_thing = get_pointed_thing({x=1,y=1,z=1})
+
+			-- Use tool to write metadata
+			local return_stack = metatool:on_use(TOOL_NAME, tool_stack, player, pointed_thing)
+
+			-- Verify that returned stack is not modified
+			if return_stack ~= nil then
+				assert.is_ItemStack(return_stack)
+				assert.equals(count, return_stack:get_count())
+				assert.equals(TOOL_NAME, return_stack:get_name())
+			end
+		end)
+
+		it("read with privileges", function()
+			local player = Player("Sam", { ban = true })
+			local tool_stack = get_tool_itemstack(TOOL_NAME)
+			local count = tool_stack:get_count()
+			local pointed_thing = get_pointed_thing({x=1,y=1,z=1})
+
+			-- Use tool to copy metadata from pointed node
+			player:_set_player_control_state("aux1", true)
+			local return_stack = metatool:on_use(TOOL_NAME, tool_stack, player, pointed_thing)
+			player:_reset_player_controls()
+
+			-- Verify that returned stack is not modified
+			if return_stack ~= nil then
+				assert.is_ItemStack(return_stack)
+				assert.equals(count, return_stack:get_count())
+				assert.equals(TOOL_NAME, return_stack:get_name())
+			end
+		end)
+
+		it("info with privileges", function()
+			local player = Player("Sam", { ban = true })
+			local tool_stack = get_tool_itemstack(TOOL_NAME)
+			local count = tool_stack:get_count()
+			local pointed_thing = get_pointed_thing({x=0,y=0,z=0})
+
+			-- Use tool info function with pointed node
+			player:_set_player_control_state("sneak", true)
+			local return_stack = metatool:on_use(TOOL_NAME, tool_stack, player, pointed_thing)
+			player:_reset_player_controls()
+
+			-- Verify that returned stack is not modified
+			if return_stack ~= nil then
+				assert.is_ItemStack(return_stack)
+				assert.equals(count, return_stack:get_count())
+				assert.equals(TOOL_NAME, return_stack:get_name())
+			end
+		end)
+
+	end)
+
+	describe("node write operation", function()
+
+		it("allows using tool with privileges", function()
+			local player = Player("Sam", { ban = true })
+			local tool_stack = get_tool_itemstack(TOOL_NAME)
+			local count = tool_stack:get_count()
+			local pointed_thing = get_pointed_thing({x=2,y=1,z=1})
+
+			-- Use tool to write metadata
+			local return_stack = metatool:on_use(TOOL_NAME, tool_stack, player, pointed_thing)
+
+			-- Verify that returned stack is not modified
+			if return_stack ~= nil then
+				assert.is_ItemStack(return_stack)
+				assert.equals(count, return_stack:get_count())
+				assert.equals(TOOL_NAME, return_stack:get_name())
+			end
+		end)
+
+	end)
+
+	describe("node read operation", function()
+
+		it("allows using tool with privileges", function()
+			local player = Player("Sam", { ban = true })
+			local tool_stack = get_tool_itemstack(TOOL_NAME)
+			local count = tool_stack:get_count()
+			local pointed_thing = get_pointed_thing({x=2,y=1,z=1})
+
+			-- Use tool to copy metadata from pointed node
+			player:_set_player_control_state("aux1", true)
+			local return_stack = metatool:on_use(TOOL_NAME, tool_stack, player, pointed_thing)
+			player:_reset_player_controls()
+
+			-- Verify that returned stack is not modified
+			if return_stack ~= nil then
+				assert.is_ItemStack(return_stack)
+				assert.equals(count, return_stack:get_count())
+				assert.equals(TOOL_NAME, return_stack:get_name())
+			end
+		end)
+
+	end)
+
+	describe("teleport tube info operation", function()
+
+		it("copy channel and display formspec for stored channel", function()
+			local player = Player("Sam", { ban = true })
+			local tool_stack = get_tool_itemstack(TOOL_NAME)
+			local count = tool_stack:get_count()
+
+			-- Use tool to copy metadata from pointed node
+			spy.on(metatool.form, "show")
+			player:_set_player_control_state("aux1", true)
+			local return_stack = metatool:on_use(TOOL_NAME, tool_stack, player, get_pointed_thing({x=2,y=1,z=1}))
+			player:_reset_player_controls()
+			assert.spy(metatool.form.show).called(0)
+
+			-- Use tool to copy metadata from pointed node
+			player:_set_player_control_state("sneak", true)
+			local return_stack = metatool:on_use(TOOL_NAME, tool_stack, player, get_pointed_thing({x=0,y=0,z=0}))
+			player:_reset_player_controls()
+			assert.spy(metatool.form.show).called(1)
+
+			-- Verify that returned stack is not modified
+			if return_stack ~= nil then
+				assert.is_ItemStack(return_stack)
+				assert.equals(count, return_stack:get_count())
+				assert.equals(TOOL_NAME, return_stack:get_name())
+			end
+		end)
+
+	end)
+
+end)


### PR DESCRIPTION
Closes #103 

* Handle invalid data supplied to tubetool teleport tube waypoint formspec constructor.
* Add few additional check for teleport tube waypoint formspec handler.
* Very basic copy/paste tests for tubetool, not targeted in any way.
* Check `areas` when using sharetool ownership transfer.
* Changes  metatool.util.pos_to_string utility function when supplied position does not seem to be valid.