### PR TITLE
Disable receiving for private receivers owned by other players

### DIFF
--- a/tubetool/init.lua
+++ b/tubetool/init.lua
@@ -45,6 +45,17 @@ tool:ns({
 		table.sort(tubes, function(a, b) return a.distance < b.distance end)
 		return tubes
 	end,
+	explode_teleport_tube_channel = function(channel)
+		-- Return channel, owner, type. Owner can be nil. Type can be nil, ; or :
+		local a, b, c = channel:match("^([^:;]+)([:;])(.*)$")
+		a = a ~= "" and a or nil
+		b = b ~= "" and b or nil
+		if b then
+			return a,b,c
+		end
+		-- No match for owner and mode
+		return nil,nil,channel
+	end,
 })
 
 -- nodes

--- a/tubetool/nodes/teleport_tube.lua
+++ b/tubetool/nodes/teleport_tube.lua
@@ -103,10 +103,22 @@ function definition:copy(node, pos, player)
 end
 
 function definition:paste(node, pos, player, data)
+	local receive = data.receive
+	-- check and update receive setting if placing private receiver but player is not owner
+	if receive == 1 then
+		local owner, mode = ns.explode_teleport_tube_channel(data.channel)
+		local name = player:get_player_name()
+		if owner ~= name and mode == ";" then
+			receive = 0
+			if type(player) == "userdata" then
+				minetest.chat_send_player(name, "Receive was disabled because you're not owner of private receiver.")
+			end
+		end
+	end
 	-- restore settings and update tube, no api available
 	local fields = {
 		channel = data.channel,
-		["cr" .. data.receive] = data.receive,
+		["cr" .. receive] = receive,
 	}
 	local nodedef = minetest.registered_nodes[node.name]
 	nodedef.on_receive_fields(pos, "", fields, player)

--- a/tubetool/spec/fixtures/pipeworks.lua
+++ b/tubetool/spec/fixtures/pipeworks.lua
@@ -22,7 +22,7 @@ local function add_tp_tube(pos, channel, receive)
 	local meta = minetest.get_meta(pos)
 	meta:set_string("channel", channel)
 	meta:set_int("can_receive", receive and 1 or 0)
-	tubedb[hash({x=1,y=1,z=1})] = {
+	tubedb[hash(pos)] = {
 		channel = channel,
 		cr = receive and 1 or 0,
 	}
@@ -34,3 +34,5 @@ world.set_node({x=0,y=0,z=0}, "default:dirt")
 add_tp_tube({x=1,y=1,z=1}, "SX:private", true)
 add_tp_tube({x=2,y=1,z=1}, "SX;receiver", true)
 add_tp_tube({x=3,y=1,z=1}, "public", true)
+add_tp_tube({x=3,y=2,z=1}, "public", true)
+add_tp_tube({x=3,y=3,z=1}, "public", true)

--- a/tubetool/spec/tool_spec.lua
+++ b/tubetool/spec/tool_spec.lua
@@ -37,6 +37,58 @@ local function get_tool_itemstack(name, data)
 	return stack
 end
 
+describe("Tool helper methods", function()
+
+	local ns = metatool.ns("tubetool")
+
+	describe("explode_teleport_tube_channel", function()
+
+		local function test_explode(channel, expect_owner, expect_mode, expect_channel)
+			local owner, mode, channel = ns.explode_teleport_tube_channel(channel)
+			assert.equals(expect_owner, owner)
+			assert.equals(expect_mode, mode)
+			assert.equals(expect_channel, channel)
+		end
+
+		it("considers foo: as owned", function() test_explode("foo:", "foo", ":", "") end)
+		it("considers foo; as owned", function() test_explode("foo;", "foo", ";", "") end)
+		it("considers foo:: as owned", function() test_explode("foo::", "foo", ":", ":") end)
+		it("considers foo;; as owned", function() test_explode("foo;;", "foo", ";", ";") end)
+		it("considers foo:bar as owned", function() test_explode("foo:bar", "foo", ":", "bar") end)
+		it("considers foo;bar as owned", function() test_explode("foo;bar", "foo", ";", "bar") end)
+		it("considers foo as public", function() test_explode("foo", nil, nil, "foo") end)
+		it("considers :foo as public", function() test_explode(":foo", nil, nil, ":foo") end)
+		it("considers ;foo as public", function() test_explode(";foo", nil, nil, ";foo") end)
+		it("considers ;:foo as public", function() test_explode(";:foo", nil, nil, ";:foo") end)
+		it("considers ;;foo as public", function() test_explode(";;foo", nil, nil, ";;foo") end)
+		it("considers : as public", function() test_explode(":", nil, nil, ":") end)
+		it("considers ; as public", function() test_explode(";", nil, nil, ";") end)
+		it("considers ;: as public", function() test_explode(";:", nil, nil, ";:") end)
+		it("considers ;; as public", function() test_explode(";;", nil, nil, ";;") end)
+
+	end)
+
+	describe("get_teleport_tubes", function()
+
+		it("returns 0 tubes", function()
+			local tubes = ns.get_teleport_tubes("nonexistent", {x=3,y=1,z=1})
+			assert.equals(0, #tubes)
+		end)
+
+		it("returns 1 tubes", function()
+			local tubes = ns.get_teleport_tubes("SX:private", {x=3,y=1,z=1})
+			assert.equals(1, #tubes)
+		end)
+
+		it("returns 3 tubes", function()
+			local tubes = ns.get_teleport_tubes("public", {x=3,y=1,z=1})
+			assert.equals(3, #tubes)
+		end)
+
+	end)
+
+end)
+
 describe("Tool behavior", function()
 
 	describe("use on teleport tube", function()


### PR DESCRIPTION
Closes #102 

Disable receive for tube when applying configuration if tool contains private receiver channel owned by other player and receive is enabled on data stored in tool memory.