### PR TITLE
Containertool upgrade handling

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -27,4 +27,5 @@ read_globals = {
 	"signs_lib",
 	"display_api",
 	"digtron",
+	"drawers",
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -28,4 +28,5 @@ read_globals = {
 	"display_api",
 	"digtron",
 	"drawers",
+	"jumpdrive",
 }

--- a/containertool/README.md
+++ b/containertool/README.md
@@ -22,10 +22,12 @@ w = ability to write
 
 * technic chests (r/w)
 * technic self contained injector (r/w)
-* technic machines with inventory (r/w)
+* technic machines with inventory (r/w + clone upgrades)
 * default wooden chests (r/w)
 * more_chests:shared (r/w)
 * digilines:chest (r/w)
+* drawers (clone upgrades)
+* jumpdrive engines (clone upgrades)
 
 ## Minetest protection checks (default settings)
 

--- a/containertool/init.lua
+++ b/containertool/init.lua
@@ -17,6 +17,24 @@ local tool = metatool:register_tool('containertool', {
 	},
 })
 
+-- Blacklist some nodes
+local tubedevice_blacklist = {
+	"^technic:.*_battery_box",
+	"^technic:.*tool_workshop",
+	"^pipeworks:dispenser",
+	"^pipeworks:nodebreaker",
+	"^pipeworks:deployer",
+	"^digtron:",
+	"^jumpdrive:",
+	"^vacuum:",
+}
+
+local function is_blacklisted(name)
+	for _,value in ipairs(tubedevice_blacklist) do
+		if name:find(value) then return true end
+	end
+end
+
 local function has_digiline(name)
 	local nodedef = minetest.registered_nodes[name]
 	return nodedef and nodedef.digiline and nodedef.digiline.receptor
@@ -63,6 +81,7 @@ end
 tool:ns({
 	description = description,
 	is_tubedevice = is_tubedevice,
+	is_blacklisted = is_blacklisted,
 	has_digiline = has_digiline,
 	get_digiline_channel = get_digiline_channel,
 	get_common_attributes = function(meta, node, pos, player)
@@ -116,6 +135,9 @@ tool:load_node_definition(dofile(modpath .. '/nodes/technic_chests.lua'))
 tool:load_node_definition(dofile(modpath .. '/nodes/technic_injector.lua'))
 tool:load_node_definition(dofile(modpath .. '/nodes/more_chests_shared.lua'))
 tool:load_node_definition(dofile(modpath .. '/nodes/digilines_chest.lua'))
+tool:load_node_definition(dofile(modpath .. '/nodes/technic_machines.lua'))
+tool:load_node_definition(dofile(modpath .. '/nodes/drawers.lua'))
+tool:load_node_definition(dofile(modpath .. '/nodes/jumpdrive.lua'))
 
 -- Register after everything else, default behavior for nodes that seems to be compatible
 minetest.register_on_mods_loaded(function()

--- a/containertool/mod.conf
+++ b/containertool/mod.conf
@@ -1,4 +1,4 @@
 name=containertool
 description=Provides metatool:containertool to copy/paste container settings
 depends=metatool
-optional_depends=default,technic_chests,more_chests,digilines
+optional_depends=default,technic_chests,more_chests,digilines,technic,drawers

--- a/containertool/nodes/common_defaults.lua
+++ b/containertool/nodes/common_defaults.lua
@@ -33,7 +33,7 @@ end
 -- Collect nodes and on_receive_fields callback functions
 local nodes = {}
 local on_receive_fields = {}
-for nodename, nodedef in pairs(minetest.registered_nodes) do print(nodename)
+for nodename, nodedef in pairs(minetest.registered_nodes) do
 	if is_tubedevice(nodename) and not blacklisted(nodename) then
 		-- Match found, add to registration list
 		table.insert(nodes, nodename)

--- a/containertool/nodes/common_defaults.lua
+++ b/containertool/nodes/common_defaults.lua
@@ -6,6 +6,7 @@ local ns = metatool.ns('containertool')
 
 -- Node feature checker
 local is_tubedevice = ns.is_tubedevice
+local is_blacklisted = ns.is_blacklisted
 -- Base metadata reader
 local get_common_attributes = ns.get_common_attributes
 -- Special metadata setters
@@ -13,28 +14,11 @@ local set_key_lock_secret = ns.set_key_lock_secret
 local set_digiline_meta = ns.set_digiline_meta
 local set_splitstacks = ns.set_splitstacks
 
--- Blacklist some nodes
-local tubedevice_blacklist = {
-	"^technic:.*_battery_box",
-	"^technic:.*tool_workshop",
-	"^pipeworks:dispenser",
-	"^pipeworks:nodebreaker",
-	"^pipeworks:deployer",
-	"^digtron:",
-	"^jumpdrive:",
-	"^vacuum:",
-}
-local function blacklisted(name)
-	for _,value in ipairs(tubedevice_blacklist) do
-		if name:find(value) then return true end
-	end
-end
-
 -- Collect nodes and on_receive_fields callback functions
 local nodes = {}
 local on_receive_fields = {}
 for nodename, nodedef in pairs(minetest.registered_nodes) do
-	if is_tubedevice(nodename) and not blacklisted(nodename) then
+	if is_tubedevice(nodename) and not is_blacklisted(nodename) then
 		-- Match found, add to registration list
 		table.insert(nodes, nodename)
 		if nodedef.on_receive_fields then

--- a/containertool/nodes/drawers.lua
+++ b/containertool/nodes/drawers.lua
@@ -1,0 +1,101 @@
+--
+-- Register drawers for Container tool
+--
+
+if not minetest.get_modpath('drawers') then
+	return
+end
+
+local ns = metatool.ns('containertool')
+
+-- Helper functions
+local get_description = ns.description
+
+local properties = {
+	on_construct = drawers.drawer_on_construct,
+	on_destruct = drawers.drawer_on_destruct,
+	on_dig = drawers.drawer_on_dig,
+	allow_metadata_inventory_put = drawers.drawer_allow_metadata_inventory_put,
+	-- not typo, take and put are same function in drawers API:
+	allow_metadata_inventory_take = drawers.drawer_allow_metadata_inventory_put,
+	on_metadata_inventory_put = drawers.add_drawer_upgrade,
+	on_metadata_inventory_take = drawers.remove_drawer_upgrade,
+}
+
+local function is_drawer(nodedef)
+	for key, value in pairs(properties) do
+		if nodedef[key] ~= value then
+			return false
+		end
+	end
+	return true
+end
+
+-- Collect nodes
+local nodes = {}
+for nodename, nodedef in pairs(minetest.registered_nodes) do
+	if is_drawer(nodedef) then
+		table.insert(nodes, nodename)
+	end
+end
+
+local definition = {
+	name = 'drawer',
+	nodes = nodes,
+	group = 'drawer',
+	protection_bypass_read = "interact",
+}
+
+function definition:copy(node, pos, player)
+	local meta = minetest.get_meta(pos)
+
+	local inv = meta:get_inventory()
+	local invlist = inv:get_list("upgrades")
+	local upgrades = {}
+	for index, stack in pairs(invlist) do
+		if not stack:is_empty() then
+			upgrades[index] = ("%s %d"):format(stack:get_name(), stack:get_count())
+		end
+	end
+
+	return {
+		description = get_description(meta, node, pos),
+		owner = meta:get("owner"),
+		inv = {
+			upgrades = upgrades,
+		}
+	}
+end
+
+function definition:paste(node, pos, player, data)
+	if type(data.inv) ~= "table" or type(data.inv.upgrades) ~= "table" then
+		return
+	end
+
+	-- Handle possible machine upgrades and player inventory
+	local meta = minetest.get_meta(pos)
+	local require_update = false
+
+	local playerinv = player:get_inventory()
+	local inv = meta:get_inventory()
+	for index, itemstring in pairs(data.inv.upgrades) do
+		if inv:get_stack("upgrades", index):is_empty() then
+			-- Target slot is empty, try to place upgrade item
+			local datastack = ItemStack(itemstring)
+			local itemcount = drawers.drawer_allow_metadata_inventory_put(pos, "upgrades", index, datastack, player)
+			-- Usually if there's space for item itemcount should be same as datastack count
+			if itemcount and itemcount > 0 and itemcount <= datastack:get_count() then
+				datastack:set_count(itemcount)
+				local playerstack = playerinv:remove_item("main", datastack)
+				inv:set_stack("upgrades", index, playerstack)
+				require_update = true
+			end
+		end
+	end
+
+	if require_update then
+		drawers.update_drawer_upgrades(pos)
+	end
+end
+
+return definition

--- a/containertool/nodes/jumpdrive.lua
+++ b/containertool/nodes/jumpdrive.lua
@@ -1,0 +1,39 @@
+--
+-- Register jumpdrive engines for Container tool
+--
+
+local definition = {
+	name = "jumpdrive_engine",
+	nodes = {
+		"jumpdrive:engine"
+	},
+	group = "jumpdrive_engine",
+	protection_bypass_read = "interact",
+}
+
+local ns = metatool.ns('containertool')
+
+-- Base metadata reader and metadata setters
+local get_common_attributes = ns.get_common_attributes
+local set_digiline_meta = ns.set_digiline_meta
+
+function definition:copy(node, pos, player)
+	local meta = minetest.get_meta(pos)
+
+	-- Read common data like owner, splitstacks, channel etc.
+	local data = get_common_attributes(meta, node, pos, player)
+
+	return data
+end
+
+function definition:paste(node, pos, player, data)
+	local meta = minetest.get_meta(pos)
+
+	-- Set common metadata values
+	set_digiline_meta(meta, {channel = data.channel}, node)
+
+	-- Handle possible machine upgrades and player inventory
+	-- TODO, Nothing here yet.
+end
+
+return definition

--- a/containertool/nodes/jumpdrive.lua
+++ b/containertool/nodes/jumpdrive.lua
@@ -2,10 +2,15 @@
 -- Register jumpdrive engines for Container tool
 --
 
+if not minetest.get_modpath('jumpdrive') then
+	return
+end
+
 local definition = {
 	name = "jumpdrive_engine",
 	nodes = {
-		"jumpdrive:engine"
+		"jumpdrive:engine",
+		"jumpdrive:area_engine",
 	},
 	group = "jumpdrive_engine",
 	protection_bypass_read = "interact",
@@ -23,6 +28,18 @@ function definition:copy(node, pos, player)
 	-- Read common data like owner, splitstacks, channel etc.
 	local data = get_common_attributes(meta, node, pos, player)
 
+	-- Get installed upgrades
+	data.inv = { upgrade = {} }
+	local inv = meta:get_inventory()
+	local invlist = inv:get_list("upgrade")
+	local upgrades = data.inv.upgrade
+
+	for index, stack in pairs(invlist) do
+		if not stack:is_empty() then
+			upgrades[index] = ("%s %d"):format(stack:get_name(), stack:get_count())
+		end
+	end
+
 	return data
 end
 
@@ -32,8 +49,30 @@ function definition:paste(node, pos, player, data)
 	-- Set common metadata values
 	set_digiline_meta(meta, {channel = data.channel}, node)
 
-	-- Handle possible machine upgrades and player inventory
-	-- TODO, Nothing here yet.
+	if type(data.inv) == "table" and type(data.inv.upgrade) == "table" then
+
+		-- Handle machine upgrades and player inventory
+		local require_update = false
+
+		local playerinv = player:get_inventory()
+		local inv = meta:get_inventory()
+		for index, itemstring in pairs(data.inv.upgrades) do
+			if inv:get_stack("upgrade", index):is_empty() then
+				-- Target slot is empty, try to place upgrade item
+				local datastack = ItemStack(itemstring)
+				if datastack:get_count() > 0 then
+					local playerstack = playerinv:remove_item("main", datastack)
+					inv:set_stack("upgrade", index, playerstack)
+					require_update = true
+				end
+			end
+		end
+
+		if require_update then
+			jumpdrive.upgrade.calculate(pos)
+		end
+	end
+
 end
 
 return definition

--- a/containertool/nodes/technic_machines.lua
+++ b/containertool/nodes/technic_machines.lua
@@ -1,0 +1,129 @@
+--
+-- Register technic chests for Container tool
+--
+
+local ns = metatool.ns('containertool')
+
+-- Helper functions
+local is_tubedevice = ns.is_tubedevice
+local is_blacklisted = ns.is_blacklisted
+-- Base metadata reader
+local get_common_attributes = ns.get_common_attributes
+-- Special metadata setters
+local set_key_lock_secret = ns.set_key_lock_secret
+local set_digiline_meta = ns.set_digiline_meta
+local set_splitstacks = ns.set_splitstacks
+
+-- Collect nodes and callback functions (no API available)
+local nodes = {}
+local allow_metadata_inventory_put = {}
+-- Remove items from machines
+--local allow_metadata_inventory_take = {}
+local on_receive_fields = {}
+
+for nodename, nodedef in pairs(minetest.registered_nodes) do
+	if nodedef.groups and nodedef.groups.technic_machine then
+		if nodedef.allow_metadata_inventory_put and nodedef.allow_metadata_inventory_take then
+			print("Possibly upgradeable technic machine: ", nodename)
+			-- Match found, add to registration list
+			table.insert(nodes, nodename)
+			allow_metadata_inventory_put[nodename] = nodedef.allow_metadata_inventory_put
+			--allow_metadata_inventory_take[nodename] = nodedef.allow_metadata_inventory_take
+			if nodedef.on_receive_fields and is_tubedevice(nodename) and not is_blacklisted(nodename) then
+				print("Tube device with on_receive_fields: ", nodename)
+				on_receive_fields[nodename] = nodedef.on_receive_fields
+			end
+		end
+	end
+end
+
+-- Inventory list names for upgrades, assume single inventory slot
+local upgrade_inventory_lists = { "upgrade1", "upgrade2" }
+
+local definition = {
+	name = 'technic_machine',
+	nodes = nodes,
+	group = 'container',
+	protection_bypass_read = "interact",
+}
+
+function definition:before_write(pos, player)
+	-- Check both owner and protection for registered machines
+	local meta = minetest.get_meta(pos)
+	local owner = meta:get("owner")
+	local owner_check = owner == nil or owner == player:get_player_name()
+	if not owner_check then
+		minetest.record_protection_violation(pos, player:get_player_name())
+	end
+	return owner_check and metatool.before_write(self, pos, player)
+end
+
+function definition:copy(node, pos, player)
+	local meta = minetest.get_meta(pos)
+
+	-- Read common data like owner, splitstacks, channel etc.
+	local data = get_common_attributes(meta, node, pos, player)
+
+	-- Look for upgrade inventories
+	data.inv = {}
+	local has_upgrades = false
+	local inv = meta:get_inventory()
+	for _,list in ipairs(upgrade_inventory_lists) do
+		if inv:get_size(list) == 1 then
+			-- Valid upgrade inventory found, read and save contents
+			local upgradestack = inv:get_stack(list, 1)
+			if upgradestack:get_count() == 1 then
+				-- Use table just to possibly allow multiple slots if needed, stack size is hardcoded to one item
+				data.inv[list] = { ("%s 1"):format(upgradestack:get_name()) }
+				has_upgrades = true
+			end
+		end
+	end
+
+	if has_upgrades then
+		data.description = ("%s with upgrades"):format(data.description)
+	end
+
+	return data
+end
+
+function definition:paste(node, pos, player, data)
+	local meta = minetest.get_meta(pos)
+
+	-- Set common metadata values
+	set_key_lock_secret(meta, data, node)
+	set_splitstacks(meta, data, node, pos)
+	set_digiline_meta(meta, {channel = data.channel}, node)
+
+	-- Handle possible machine upgrades and player inventory
+	if type(data.inv) == "table" then
+		local playerinv = player:get_inventory()
+		local inv = meta:get_inventory()
+		for _,list in ipairs(upgrade_inventory_lists) do
+			-- Check if there's anything to insert and make sure target is empty
+			if data.inv[list] and data.inv[list][1] and inv:get_size(list) == 1 and inv:is_empty(list) then
+				local datastack = ItemStack(data.inv[list][1])
+				-- Allow only itemstacks with single item, has to be changed if stackable upgrades are allowed
+				if not datastack:is_empty() then
+					local itemcount = allow_metadata_inventory_put[node.name](pos, list, 1, datastack, player)
+					if itemcount and itemcount > 0 then
+						datastack:set_count(itemcount)
+						local playerstack = playerinv:remove_item("main", datastack)
+						inv:set_stack(list, 1, playerstack)
+					end
+				end
+			end
+			-- Remove items from machine
+			--local itemcount = allow_metadata_inventory_take[node.name](pos, list, index, stack, player)
+		end
+	end
+
+	-- Yeah, sorry... everyone just keeps their internal stuff "protected"
+	if on_receive_fields[node.name] then
+		if not pcall(function()on_receive_fields[node.name](pos, "", {}, player)end) then
+			pcall(function()on_receive_fields[node.name](pos, "", {quit=1}, player)end)
+		end
+	end
+end
+
+return definition

--- a/containertool/spec/fixtures/nodes.lua
+++ b/containertool/spec/fixtures/nodes.lua
@@ -37,3 +37,5 @@ minetest.register_node(":technic:injector", {
 	end,
 	on_receive_fields = function(...) print(...) end,
 })
+
+drawers = {}


### PR DESCRIPTION
Some upgrade cloning support done for:
- [x] Machines included in technic mod
- [x] Drawers registered using `drawers.register_drawer`
- [x] Jumpdrive engines

Tested well enough:
- [x] Machines included in technic mod
- [x] Drawers registered using `drawers.register_drawer`
- [x] Jumpdrive engines

Currently only placing upgrades is supported, removal or replacement of upgrades is not currently possible.
TBD: What to do with removal and/or replacement support? Is it good or bad, behavior will change and only adding upgrades will not be possible.

For upgrade removal, what to do when inventory is full? Options:
- [ ] Upgrade removal is bad, do not allow it at all.
- [ ] Remove items and drop to ground.
- [ ] Prevent removing items from container.

What to do if player does not have all required items? Currently it will place all upgrades that are available and simply leave slots empty if player does not have enough items in inventory.