### PR TITLE
Sharetool tptube support

### DIFF
--- a/containertool/spec/mineunit.conf
+++ b/containertool/spec/mineunit.conf
@@ -1,4 +1,3 @@
-modname = "containertool"
 fixture_paths = {
 	"spec/fixtures",
 	"../metatool/spec/fixtures",

--- a/metatool/spec/fixtures/pipeworks.lua
+++ b/metatool/spec/fixtures/pipeworks.lua
@@ -11,9 +11,12 @@ local tubedb = {}
 
 pipeworks = {
 	tptube = {
+		hash = hash,
 		get_db = function()
 			return tubedb
 		end,
+		set_tube = function() end,
+		update_meta = function() end,
 	}
 }
 

--- a/metatool/spec/mineunit.conf
+++ b/metatool/spec/mineunit.conf
@@ -1,1 +1,0 @@
-modname = "metatool"

--- a/sharetool/init.lua
+++ b/sharetool/init.lua
@@ -27,18 +27,23 @@ local sharetool = {
 	},
 }
 
+local function send_confirmation_message(player, targetname, nodename, result)
+	local success = type(result) ~= 'table' or result.success or result.success == nil
+	minetest.chat_send_player(player:get_player_name(),
+		(type(result) == 'table' and result.description)
+		or (success
+			and S('Node %s ownership changed to %s', nodename, targetname)
+			or S('Failed %s ownership change to %s', nodename, targetname)
+		)
+	)
+end
+
 --luacheck: ignore unused argument data group pointed_thing
 function sharetool:on_read_node(player, pointed_thing, node, pos)
 	local definition = self.nodes[node.name]
 	if definition then
 		local res = definition:copy(node, pos, player)
-		local name = player:get_player_name()
-		local success = type(res) ~= 'table' or res.success or res.success == nil
-		if success then
-			minetest.chat_send_player(name, S('Node %s ownership changed to %s', node.name, name))
-		else
-			minetest.chat_send_player(name, S('Failed %s ownership change to %s', node.name, name))
-		end
+		send_confirmation_message(player, player:get_player_name(), node.name, res)
 	end
 	-- Return nil to keep tool without metadata
 end
@@ -47,14 +52,7 @@ function sharetool:on_write_node(data, group, player, pointed_thing, node, pos)
 	local definition = self.nodes[node.name]
 	if definition then
 		local res = definition:paste(node, pos, player)
-		local name = player:get_player_name()
-		local sname = self.settings.shared_account
-		local success = type(res) ~= 'table' or res.success or res.success == nil
-		if success then
-			minetest.chat_send_player(name, S('Node %s ownership changed to %s', node.name, sname))
-		else
-			minetest.chat_send_player(name, S('Failed %s ownership change to %s', node.name, sname))
-		end
+		send_confirmation_message(player, self.settings.shared_account, node.name, res)
 	end
 end
 
@@ -153,4 +151,5 @@ tool:load_node_definition(dofile(modpath .. '/nodes/travelnet.lua'))
 tool:load_node_definition(dofile(modpath .. '/nodes/missions.lua'))
 tool:load_node_definition(dofile(modpath .. '/nodes/mapserver.lua'))
 tool:load_node_definition(dofile(modpath .. '/nodes/digiline_global_memory.lua'))
+tool:load_node_definition(dofile(modpath .. '/nodes/pipeworks.lua'))
 tool:load_node_definition(dofile(modpath .. '/nodes/any.lua'))

--- a/sharetool/mod.conf
+++ b/sharetool/mod.conf
@@ -1,4 +1,4 @@
 name=sharetool
 description=Provides metatool:sharetool to manage shared nodes ownership
 depends=metatool
-optional_depends=travelnet,homedecor_books,missions,mapserver,digiline_global_memory
+optional_depends=travelnet,homedecor_books,missions,mapserver,digiline_global_memory,pipeworks

--- a/sharetool/nodes/pipeworks.lua
+++ b/sharetool/nodes/pipeworks.lua
@@ -1,0 +1,103 @@
+--
+-- Register teleport tubes for sharetool
+--
+
+if not pipeworks or not pipeworks.tptube or not pipeworks.tptube.set_tube or not pipeworks.tptube.update_meta then
+	minetest.log("error", "loading teleport tubes for sharetool failed, update your pipeworks mod")
+	return
+end
+
+local S = metatool.S
+local getdesc = metatool.util.description --(pos, node, meta)
+local pipeworks_translator = minetest.get_translator("pipeworks")
+
+-- get namespace defined at sharetool init.lua
+local ns = metatool.ns('sharetool')
+
+local nodenameprefix = "pipeworks:teleport_tube_"
+
+-- teleport tubes
+local nodes = {}
+for i=1,10 do
+	table.insert(nodes, nodenameprefix .. i)
+end
+
+local definition = {
+	name = 'teleport-tube',
+	nodes = nodes,
+	group = 'teleport-tube',
+}
+
+function definition:before_read(pos, player)
+	if ns:can_bypass(pos, player, 'owner') or metatool.before_read(self, pos, player, true) then
+		-- Player is allowed to bypass protections or operate in area
+		return true
+	end
+	return false
+end
+
+function definition:before_write(pos, player)
+	if ns:can_bypass(pos, player, 'owner') or metatool.before_write(self, pos, player, true) then
+		-- Player is allowed to bypass protections or operate in area
+		return true
+	end
+	return false
+end
+
+local function explode_teleport_tube_channel(channel)
+	-- Return channel, owner, type. Owner can be nil. Type can be nil, ; or :
+	local a, b, c = channel:match("^([^:;]+)([:;])(.*)$")
+	a = a ~= "" and a or nil
+	b = b ~= "" and b or nil
+	if b then
+		return a,b,c
+	end
+	-- No match for owner and mode
+	return nil,nil,channel
+end
+
+local function transfer_to(newowner, node, pos, player)
+	local meta = minetest.get_meta(pos)
+	local raw_channel = meta:get("channel")
+	if raw_channel then
+		local owner, mode, channel = explode_teleport_tube_channel(raw_channel)
+		if not owner or not mode then
+			return
+		end
+
+		channel = newowner .. mode .. channel
+		if channel == raw_channel then
+			return {
+				success = false,
+				description = S("%s is already owner of %s", newowner, getdesc(pos, node, meta))
+			}
+		end
+
+		-- Change channel ownership and mark as shared node
+		local receive = meta:get_int("can_receive")
+		meta:set_string("channel", channel)
+		pipeworks.tptube.update_meta(meta, receive == 1)
+		pipeworks.tptube.set_tube(pos, channel, receive)
+		local cr_description = (receive == 1) and "sending and receiving" or "sending"
+		meta:set_string("infotext", pipeworks_translator("Teleportation Tube @1 on '@2'", cr_description, channel))
+
+		ns.mark_shared(meta)
+		return { success = true }
+	end
+end
+
+function definition:copy(node, pos, player)
+	-- Copy function does not really copy anything here
+	-- but instead it will claim ownership of pointed
+	-- node and mark it as shared node
+	return transfer_to(player:get_player_name(), node, pos, player) or { success = false }
+end
+
+function definition:paste(node, pos, player, data)
+	-- Paste function does not really paste anything here
+	-- but instead it will restore ownership of pointed
+	-- node and mark it as shared node
+	return transfer_to(ns.shared_account, node, pos, player) or { success = false }
+end
+
+return definition

--- a/sharetool/spec/mineunit.conf
+++ b/sharetool/spec/mineunit.conf
@@ -1,4 +1,3 @@
-modname = "sharetool"
 fixture_paths = {
 	"spec/fixtures",
 	"../metatool/spec/fixtures",

--- a/sharetool/spec/tool_spec.lua
+++ b/sharetool/spec/tool_spec.lua
@@ -11,6 +11,7 @@ mineunit("protection")
 mineunit("default/functions")
 
 fixture("metatool")
+fixture("pipeworks")
 
 minetest.register_node(":default:dirt", {})
 minetest.register_node(":digiline_global_memory:controller", {})


### PR DESCRIPTION
Allows using sharetool to set teleport tube channel owner to/from shared account.