### PR TITLE
Tubetool allow listing only shared or owned channel

### DIFF
--- a/tubetool/nodes/any.lua
+++ b/tubetool/nodes/any.lua
@@ -30,6 +30,16 @@ function definition:info(node, pos, player, itemstack)
 		)
 		return
 	end
+
+	-- Done here instead of before_info as it uses tool data instead of target data to deny or allow usage.
+	if not ns.allow_teleport_tube_info(player, channel) then
+		minetest.chat_send_player(
+			player:get_player_name(),
+			('You are not allowed to list locations on stored channel %s.'):format(channel)
+		)
+		return
+	end
+
 	local tubes = ns.get_teleport_tubes(channel, pos)
 	metatool.form.show(player, 'tubetool:teleport_tube_list', {pos = pos, channel = channel, tubes = tubes})
 end

--- a/tubetool/nodes/teleport_tube.lua
+++ b/tubetool/nodes/teleport_tube.lua
@@ -67,13 +67,17 @@ local definition = {
 }
 
 function definition:before_info(pos, player)
-	if  metatool.before_info(self, pos, player, true) then
-		-- Player is allowed to bypass protections or operate in area
-		return true
-	end
-	-- Allow bypass info protection if tube is marked as shared with sharetool
+	-- No actual protection checks because this only operates on stored data
 	local meta = minetest.get_meta(pos)
-	return meta:get_int('sharetool_shared_node') == 1
+	local channel = meta:get_string("channel")
+	if not ns.allow_teleport_tube_info(player, channel) then
+		minetest.chat_send_player(
+			player:get_player_name(),
+			('You are not allowed to list locations on channel %s.'):format(channel)
+		)
+		return false
+	end
+	return true
 end
 
 function definition:info(node, pos, player)

--- a/tubetool/spec/tool_spec.lua
+++ b/tubetool/spec/tool_spec.lua
@@ -50,21 +50,46 @@ describe("Tool helper methods", function()
 			assert.equals(expect_channel, channel)
 		end
 
-		it("considers foo: as owned", function() test_explode("foo:", "foo", ":", "") end)
-		it("considers foo; as owned", function() test_explode("foo;", "foo", ";", "") end)
-		it("considers foo:: as owned", function() test_explode("foo::", "foo", ":", ":") end)
-		it("considers foo;; as owned", function() test_explode("foo;;", "foo", ";", ";") end)
+		it("considers foo: as owned",    function() test_explode("foo:",    "foo", ":", "") end)
+		it("considers foo; as owned",    function() test_explode("foo;",    "foo", ";", "") end)
+		it("considers foo:: as owned",   function() test_explode("foo::",   "foo", ":", ":") end)
+		it("considers foo;; as owned",   function() test_explode("foo;;",   "foo", ";", ";") end)
 		it("considers foo:bar as owned", function() test_explode("foo:bar", "foo", ":", "bar") end)
 		it("considers foo;bar as owned", function() test_explode("foo;bar", "foo", ";", "bar") end)
-		it("considers foo as public", function() test_explode("foo", nil, nil, "foo") end)
-		it("considers :foo as public", function() test_explode(":foo", nil, nil, ":foo") end)
-		it("considers ;foo as public", function() test_explode(";foo", nil, nil, ";foo") end)
-		it("considers ;:foo as public", function() test_explode(";:foo", nil, nil, ";:foo") end)
-		it("considers ;;foo as public", function() test_explode(";;foo", nil, nil, ";;foo") end)
-		it("considers : as public", function() test_explode(":", nil, nil, ":") end)
-		it("considers ; as public", function() test_explode(";", nil, nil, ";") end)
-		it("considers ;: as public", function() test_explode(";:", nil, nil, ";:") end)
-		it("considers ;; as public", function() test_explode(";;", nil, nil, ";;") end)
+		it("considers foo as public",    function() test_explode("foo",     nil,   nil, "foo") end)
+		it("considers :foo as public",   function() test_explode(":foo",    nil,   nil, ":foo") end)
+		it("considers ;foo as public",   function() test_explode(";foo",    nil,   nil, ";foo") end)
+		it("considers ;:foo as public",  function() test_explode(";:foo",   nil,   nil, ";:foo") end)
+		it("considers ;;foo as public",  function() test_explode(";;foo",   nil,   nil, ";;foo") end)
+		it("considers : as public",      function() test_explode(":",       nil,   nil, ":") end)
+		it("considers ; as public",      function() test_explode(";",       nil,   nil, ";") end)
+		it("considers ;: as public",     function() test_explode(";:",      nil,   nil, ";:") end)
+		it("considers ;; as public",     function() test_explode(";;",      nil,   nil, ";;") end)
+
+	end)
+
+	describe("allow_teleport_tube_info", function()
+
+		local p1 = Player("p1", {})
+		local p2 = Player("p2", { interact = true })
+		local p3 = Player("p3", { interact = true, protection_bypass = true })
+
+		local function test_allow(player, channel, expect_result)
+			local result = ns.allow_teleport_tube_info(player, channel)
+			assert.equals(expect_result, result)
+		end
+
+		it("allows public for p1",       function() test_allow(p1, "pubch", true) end)
+		it("allows public for p2",       function() test_allow(p2, "pubch", true) end)
+		it("allows public for p3",       function() test_allow(p3, "pubch", true) end)
+
+		it("allows receiver for owner",  function() test_allow(p1, "p1;ch", true) end)
+		it("allows receiver for others", function() test_allow(p2, "p1;ch", true) end)
+		it("allows receiver for bypass", function() test_allow(p3, "p1;ch", true) end)
+
+		it("allows private for owner",   function() test_allow(p1, "p1:ch", true) end)
+		it("denies private for others",  function() test_allow(p2, "p1:ch", false) end)
+		it("allows private for bypass",  function() test_allow(p3, "p1:ch", true) end)
 
 	end)
 


### PR DESCRIPTION
Fixes protection check bug that allowed different operations / channel types to be listed based on in world protection.
Ignore world protections and only rely on teleport tube channel when checking if tube location listing is allowed.
Stored data and targeted in world tube checks are done same way.

* public channels can be listed by anyone.
* private receivers can be listed by anyone.
* private channels can be listed by owner.
* protection_bypass can list all channels.
