### PR TITLE
Use new teleport tube API if available

### DIFF
--- a/sharetool/nodes/pipeworks.lua
+++ b/sharetool/nodes/pipeworks.lua
@@ -74,10 +74,16 @@ end
 
 local function set_channel(pos, meta, channel, receive)
 	meta:set_string("channel", channel)
+	-- new api wont set meta for can_receive so we need to set it here
+	meta:set_int("can_receive", receive)
+	-- old api requires second update_meta arg and sets meta, also required for new api but ignores second arg
 	pipeworks.tptube.update_meta(meta, receive == 1)
 	pipeworks.tptube.set_tube(pos, channel, receive)
-	local cr_description = (receive == 1) and "sending and receiving" or "sending"
-	meta:set_string("infotext", pipeworks_translator("Teleportation Tube @1 on '@2'", cr_description, channel))
+	if not pipeworks.tptube.update_tube then
+		-- old api wont set infotext, if it seems like old api then do it here
+		local cr_description = (receive == 1) and "sending and receiving" or "sending"
+		meta:set_string("infotext", pipeworks_translator("Teleportation Tube @1 on '@2'", cr_description, channel))
+	end
 	ns.mark_shared(meta)
 end
 

--- a/tubetool/nodes/teleport_tube.lua
+++ b/tubetool/nodes/teleport_tube.lua
@@ -130,7 +130,7 @@ function definition:paste(node, pos, player, data)
 		end
 	end
 	-- restore settings and update teleport tube
-	if type(pipeworks.tptube) == "table" and type(pipeworks.tptube.set_tube) == "function" then
+	if type(pipeworks.tptube) == "table" and type(pipeworks.tptube.update_tube) == "function" then
 		-- using pipeworks api, update_tube will also check permissions
 		pipeworks.tptube.update_tube(pos, data.channel, receive, name)
 	else


### PR DESCRIPTION
Fixes #124 

Try to find out Pipeworks API version and use API if it is available.
Also adds support for new Pipeworks API while attempting to keep support for old API attempting to detect points where public function signatures in Pipeworks API were changed.

Should allow setting receive configuration again with rewritten Pipeworks API.