### PR TITLE
Remove old travelnet API function call

### DIFF
--- a/sharetool/init.lua
+++ b/sharetool/init.lua
@@ -132,19 +132,17 @@ tool:ns({
 		-- Remove old network link
 		if current_owner_travelnets[network] then
 			current_owner_travelnets[network][station] = nil
-			-- save current owners travelnets
+			-- Save current owners travelnets
 			travelnet.set_travelnets(current_owner, current_owner_travelnets)
 		end
 		-- Update owner
 		meta:set_string('owner', owner)
 		-- Attach to network
 		new_owner_travelnets[network][station] = {pos=pos, timestamp=os.time()}
-		-- save new owners travelnets
+		-- Save new owners travelnets
 		travelnet.set_travelnets(owner, new_owner_travelnets)
 		-- Update formspec to reflect changes
 		travelnet.update_formspec(pos, owner, nil)
-		-- Save travelnet database
-		travelnet.save_data()
 		return true
 	end
 })


### PR DESCRIPTION
The sharetool was updated to support the new travelnet API in https://github.com/S-S-X/metatool/commit/cceb7944edf6c08593111d02f01ca2d5c03deecc, but the call to `travelnet.save_data()` was not removed. This PR fixes that.